### PR TITLE
Add CI with github actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,18 @@
+name: GitHub Action for blk-archive
+run-name: ${{ github.actor }} is running blk-archive unit tests 🚀
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name:  Setup and run tests
+        run: sudo sudo test/vm_test.sh
+      - run: echo "🍏 This job's status is ${{ job.status }}."
+

--- a/test/vm_test.sh
+++ b/test/vm_test.sh
@@ -14,6 +14,9 @@ source "$HOME/.cargo/env" || exit 1
 
 cargo build || exit 1
 
+# Run the rust tests
+cargo test || exit 1
+
 export PATH=$PATH:`pwd`/target/debug
 
 if [ ! -d dmtest-python ]; then
@@ -30,10 +33,7 @@ loop2=$(losetup -f --show /block2.img)
 loop3=$(losetup -f --show /block3.img)
 
 
-
-
-# install linux source tree
-
+# Unable to run rolling linux test as we don't have enough disk space in the CI VMs.
 
 # setup the configuration file for dmtest-python
 cd dmtest-python || exit 1

--- a/test/vm_test.sh
+++ b/test/vm_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/bash
+
+# Install all the dependencies
+export DEBIAN_FRONTEND="noninteractive"
+apt-get update -y || exit 1
+
+apt-get install git gcc clang-tools libdevmapper-dev pkg-config mount python3 python3-toml python3-pudb -y || exit 1
+
+# install rust via rustup as packages are too old on ubuntu
+curl https://sh.rustup.rs -sSf | sh -s -- -y || exit 1
+
+# Get rust tools in path
+source "$HOME/.cargo/env" || exit 1
+
+cargo build || exit 1
+
+export PATH=$PATH:`pwd`/target/debug
+
+if [ ! -d dmtest-python ]; then
+    git clone https://github.com/jthornber/dmtest-python.git || exit 1
+fi
+
+# Create the block devices
+truncate -s 1T /block1.img || exit 1
+truncate -s 1T /block2.img || exit 1
+truncate -s 1T /block3.img || exit 1
+
+loop1=$(losetup -f --show /block1.img)
+loop2=$(losetup -f --show /block2.img)
+loop3=$(losetup -f --show /block3.img)
+
+
+
+
+# install linux source tree
+
+
+# setup the configuration file for dmtest-python
+cd dmtest-python || exit 1
+
+echo "metadata_dev = '$loop1'" > config.toml
+echo "data_dev = '$loop2'" >> config.toml
+echo "disable_by_id_check = true" >> config.toml
+
+
+export DMTEST_RESULT_SET=unit-test
+./dmtest health || exit 1
+./dmtest run blk-archive/unit/combinations || exit 1
+


### PR DESCRIPTION
This PR add CI testing using GH actions and runs:

- Rust unit tests
- dmtest-python functional test `blk-archive/unit/combinations`

We are unable to run the dmtest-python `blk-archive/rolling-snaps` as we don't have enough block space.  GH actions is limited to 17G.  I'm unable to make this test work in a local VM with 25G using a minimal install of ubuntu.

I'm investigating using packit and the test farm, to see if we can run all the functional tests on it.