### PR TITLE
Handle interrupted pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,8 +116,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "bincode",
  "blake2",
- "bytebuffer",
  "byteorder",
  "chrono",
  "clap",
@@ -149,15 +158,6 @@ name = "bumpalo"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
-
-[[package]]
-name = "bytebuffer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7bfaf7cd08cacd74cdc6b521c37ac39cbc92692e5ab5c21ed5657a749b577c"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "bytemuck"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "anyhow",
  "atty",
  "blake2",
+ "bytebuffer",
  "byteorder",
  "chrono",
  "clap",
@@ -148,6 +149,15 @@ name = "bumpalo"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+
+[[package]]
+name = "bytebuffer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7bfaf7cd08cacd74cdc6b521c37ac39cbc92692e5ab5c21ed5657a749b577c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "bytemuck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0"
 atty = "0.2"
 blake2 = "0.10"
+bytebuffer = "2.2"
 byteorder = "1.4"
 chrono = "0.4"
 clap = { version = "3.1.0", features = ["cargo"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 atty = "0.2"
+bincode = "1.3"
 blake2 = "0.10"
-bytebuffer = "2.2"
 byteorder = "1.4"
 chrono = "0.4"
 clap = { version = "3.1.0", features = ["cargo"] }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use clap::ArgMatches;
+
+use crate::output::Output;
+use crate::paths;
+use crate::slab::*;
+
+pub fn run(matches: &ArgMatches, _output: Arc<Output>) -> Result<()> {
+    let archive_dir = Path::new(matches.value_of("ARCHIVE").unwrap()).canonicalize()?;
+
+    env::set_current_dir(archive_dir.clone())?;
+
+    let data_path = paths::data_path();
+    let hashes_path = paths::hashes_path();
+
+    let num_data_slabs = SlabFile::verify(data_path.clone())?;
+    let num_hash_slabs = SlabFile::verify(hashes_path.clone())?;
+
+    if num_data_slabs != num_hash_slabs {
+        return Err(anyhow!("Number of slab entries in data slab {num_data_slabs} != {num_hash_slabs} in hashes file!"));
+    }
+
+    Ok(())
+}

--- a/src/check.rs
+++ b/src/check.rs
@@ -181,4 +181,15 @@ impl CheckPoint {
             Ok(Some(cp))
         }
     }
+
+    pub fn interrupted() -> Result<()> {
+        let root = env::current_dir()?;
+        match Self::read(root).context("error while checking for checkpoint file!")? {
+            Some(cp) => Err(anyhow!(
+                "pack operation of {} was interrupted, run verify-all -r to correct",
+                cp.source_path
+            )),
+            None => Ok(()),
+        }
+    }
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,15 +1,30 @@
+use anyhow::{anyhow, Context, Result};
+use serde_derive::{Deserialize, Serialize};
 use std::env;
-use std::path::Path;
+use std::fs;
+use std::io::Write;
+use std::os::unix::prelude::OpenOptionsExt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
 use clap::ArgMatches;
 
 use crate::output::Output;
 use crate::paths;
 use crate::slab::*;
 
-pub fn run(matches: &ArgMatches, _output: Arc<Output>) -> Result<()> {
+fn remove_incomplete_stream(cp: &CheckPoint) -> Result<()> {
+    // Data and hashes has been validated, remove the stream file directory
+    let stream_dir_to_del = PathBuf::from(&cp.stream_path).canonicalize()?;
+    fs::remove_dir_all(stream_dir_to_del.clone())?;
+
+    // Everything should be good now, remove the check point
+    CheckPoint::end()?;
+
+    Ok(())
+}
+
+pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     let archive_dir = Path::new(matches.value_of("ARCHIVE").unwrap()).canonicalize()?;
     let repair = matches.is_present("REPAIR");
 
@@ -18,15 +33,152 @@ pub fn run(matches: &ArgMatches, _output: Arc<Output>) -> Result<()> {
     let data_path = paths::data_path();
     let hashes_path = paths::hashes_path();
 
-    let num_data_slabs = SlabFile::verify(data_path.clone(), repair)?;
-    let num_hash_slabs = SlabFile::verify(hashes_path.clone(), repair)?;
+    output.report.progress(0);
+    output.report.set_title("Verifying archive");
 
-    if num_data_slabs != num_hash_slabs {
-        return Err(anyhow!(
-            "Number of slab entries in data slab {num_data_slabs} \
-            != {num_hash_slabs} in hashes file!"
-        ));
+    // Load up a check point if we have one.
+    let cp = CheckPoint::read(archive_dir.clone())?;
+
+    let num_data_slabs = SlabFile::verify(data_path.clone(), repair);
+    output.report.progress(25);
+    let num_hash_slabs = SlabFile::verify(hashes_path.clone(), repair);
+    output.report.progress(50);
+    if (num_data_slabs.is_err() || num_hash_slabs.is_err())
+        || (num_data_slabs.as_ref().unwrap() != num_hash_slabs.as_ref().unwrap())
+    {
+        if !repair || cp.is_none() {
+            return Err(anyhow!(
+                "The number of slabs in the data file {} != {} number in hashes file!",
+                num_data_slabs?,
+                num_hash_slabs?
+            ));
+        }
+
+        output.report.set_title("Repairing archive ...");
+
+        // We tried to do a non-loss data fix which didn't work, we now have to revert the data
+        // slab to a known good state. It doesn't matter if one of the slabs verifies ok, we need
+        // to be a matched set.  So we put both is known good state, but before we do we will make
+        // sure our slabs are bigger than our starting sizes.  If they aren't there is nothing we
+        // can do to fix this and we won't do anything.
+        let cp = cp.unwrap();
+        let data_meta = fs::metadata(&data_path)?;
+        let hashes_meta = fs::metadata(&hashes_path)?;
+
+        if data_meta.len() >= cp.data_start_size && hashes_meta.len() >= cp.hash_start_size {
+            output
+                .report
+                .info("Rolling back archive to previous state...");
+
+            // Make sure the truncated size verifies by verifying what part we are keeping first
+            SlabFile::truncate(data_path.clone(), cp.data_start_size, false)?;
+            SlabFile::truncate(hashes_path.clone(), cp.hash_start_size, false)?;
+
+            // Do the actual truncate which also fixes up the offsets file to match
+            SlabFile::truncate(data_path, cp.data_start_size, true)?;
+            output.report.progress(75);
+            SlabFile::truncate(hashes_path, cp.hash_start_size, true)?;
+
+            remove_incomplete_stream(&cp)?;
+            output.report.progress(100);
+            output.report.info("Archive restored to previous state.");
+        } else {
+            return Err(anyhow!(
+                "We're unable to repair this archive, check point sizes > \
+                current file sizes, missing data!"
+            ));
+        }
+    } else if repair && cp.is_some() {
+        remove_incomplete_stream(&cp.unwrap())?;
     }
 
     Ok(())
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CheckPoint {
+    pub source_path: String,
+    pub stream_path: String,
+    pub data_start_size: u64,
+    pub hash_start_size: u64,
+    pub data_curr_size: u64,
+    pub hash_curr_size: u64,
+    pub input_offset: u64,
+    pub checksum: u64,
+}
+
+pub fn checkpoint_path(root: &str) -> PathBuf {
+    [root, "checkpoint.toml"].iter().collect()
+}
+
+impl CheckPoint {
+    pub fn start(
+        source_path: &str,
+        stream_path: &str,
+        data_start_size: u64,
+        hash_start_size: u64,
+    ) -> Self {
+        CheckPoint {
+            source_path: String::from(source_path),
+            stream_path: String::from(stream_path),
+            data_start_size,
+            hash_start_size,
+            data_curr_size: data_start_size,
+            hash_curr_size: hash_start_size,
+            input_offset: 0,
+            checksum: 0,
+        }
+    }
+
+    pub fn write(&mut self, root: &Path) -> Result<()> {
+        let file_name = checkpoint_path(
+            root.to_str()
+                .ok_or_else(|| anyhow!("Invalid root path {}", root.display()))?,
+        );
+
+        {
+            //TODO: make the checksum mean somthing and check it in the read.  It's important
+            // that the values are correct before we destroy data during a repair.  Maybe this
+            // file shouldn't be in a human readable format?
+            let mut output = fs::OpenOptions::new()
+                .read(false)
+                .write(true)
+                .custom_flags(libc::O_SYNC)
+                .create_new(true)
+                .open(file_name)
+                .context("Previous operation interrupted, please run verify-all")?;
+
+            let toml = toml::to_string(self).unwrap();
+            output.write_all(toml.as_bytes())?;
+        }
+
+        // Sync containing dentry to ensure checkpoint file exists
+        fs::File::open(root)?.sync_all()?;
+
+        Ok(())
+    }
+
+    pub fn end() -> Result<()> {
+        let root = env::current_dir()?;
+        let root_str = root.clone().into_os_string().into_string().unwrap();
+        let cp_file = checkpoint_path(root_str.as_str());
+
+        fs::remove_file(cp_file).context("error removing checkpoint file!")?;
+
+        fs::File::open(root)?.sync_all()?;
+        Ok(())
+    }
+
+    fn read<P: AsRef<Path>>(root: P) -> Result<Option<Self>> {
+        let file_name = checkpoint_path(root.as_ref().to_str().unwrap());
+        let content = fs::read_to_string(file_name);
+        if content.is_err() {
+            // No checkpoint
+            Ok(None)
+        } else {
+            let cp: CheckPoint =
+                toml::from_str(&content.unwrap()).context("couldn't parse checkpoint file")?;
+            Ok(Some(cp))
+        }
+    }
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -41,11 +41,11 @@ pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     output.report.set_title("Verifying archive");
 
     // Load up a check point if we have one.
-    let cp = CheckPoint::read(archive_dir.clone())?;
+    let cp = CheckPoint::read(&archive_dir)?;
 
-    let num_data_slabs = SlabFile::verify(data_path.clone(), repair);
+    let num_data_slabs = SlabFile::verify(&data_path, repair);
     output.report.progress(25);
-    let num_hash_slabs = SlabFile::verify(hashes_path.clone(), repair);
+    let num_hash_slabs = SlabFile::verify(&hashes_path, repair);
     output.report.progress(50);
     if (num_data_slabs.is_err() || num_hash_slabs.is_err())
         || (num_data_slabs.as_ref().unwrap() != num_hash_slabs.as_ref().unwrap())
@@ -75,8 +75,8 @@ pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
                 .info("Rolling back archive to previous state...");
 
             // Make sure the truncated size verifies by verifying what part we are keeping first
-            SlabFile::truncate(data_path.clone(), cp.data_start_size, false)?;
-            SlabFile::truncate(hashes_path.clone(), cp.hash_start_size, false)?;
+            SlabFile::truncate(&data_path, cp.data_start_size, false)?;
+            SlabFile::truncate(&hashes_path, cp.hash_start_size, false)?;
 
             // Do the actual truncate which also fixes up the offsets file to match
             SlabFile::truncate(data_path, cp.data_start_size, true)?;

--- a/src/check.rs
+++ b/src/check.rs
@@ -11,17 +11,21 @@ use crate::slab::*;
 
 pub fn run(matches: &ArgMatches, _output: Arc<Output>) -> Result<()> {
     let archive_dir = Path::new(matches.value_of("ARCHIVE").unwrap()).canonicalize()?;
+    let repair = matches.is_present("REPAIR");
 
     env::set_current_dir(archive_dir.clone())?;
 
     let data_path = paths::data_path();
     let hashes_path = paths::hashes_path();
 
-    let num_data_slabs = SlabFile::verify(data_path.clone())?;
-    let num_hash_slabs = SlabFile::verify(hashes_path.clone())?;
+    let num_data_slabs = SlabFile::verify(data_path.clone(), repair)?;
+    let num_hash_slabs = SlabFile::verify(hashes_path.clone(), repair)?;
 
     if num_data_slabs != num_hash_slabs {
-        return Err(anyhow!("Number of slab entries in data slab {num_data_slabs} != {num_hash_slabs} in hashes file!"));
+        return Err(anyhow!(
+            "Number of slab entries in data slab {num_data_slabs} \
+            != {num_hash_slabs} in hashes file!"
+        ));
     }
 
     Ok(())

--- a/src/dump_stream.rs
+++ b/src/dump_stream.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::check::*;
 use crate::output::Output;
 use crate::stream::*;
 
@@ -14,6 +15,7 @@ pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     let stream = matches.value_of("STREAM").unwrap();
 
     env::set_current_dir(archive_dir)?;
+    CheckPoint::interrupted()?;
 
     let mut d = Dumper::new(stream)?;
     d.dump(output)

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -54,4 +54,15 @@ pub fn hash_32(v: &[u8]) -> Hash32 {
     hasher.finalize()
 }
 
+pub fn hash_256_hash_64_iov(iov: &IoVec) -> (Hash256, u64) {
+    let h = hash_256_iov(iov);
+    let mini_hash = hash_64(&h[..]);
+    (h, u64::from_le_bytes(mini_hash.into()))
+}
+pub fn hash_256_hash_64(v: &[u8]) -> (Hash256, u64) {
+    let h = hash_256(v);
+    let mini_hash = hash_64(&h[..]);
+    (h, u64::from_le_bytes(mini_hash.into()))
+}
+
 //-----------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod check;
 pub mod chunkers;
 pub mod config;
 pub mod content_sensitive_splitter;

--- a/src/list.rs
+++ b/src/list.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::check::*;
 use crate::config;
 use crate::output::Output;
 
@@ -22,6 +23,7 @@ pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     let archive_dir = Path::new(matches.value_of("ARCHIVE").unwrap()).canonicalize()?;
 
     env::set_current_dir(&archive_dir)?;
+    CheckPoint::interrupted()?;
 
     let paths = fs::read_dir(Path::new("./streams"))?;
     let stream_ids = paths

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::process::exit;
 use std::sync::Arc;
 use thinp::report::*;
 
+use blk_archive::check;
 use blk_archive::create;
 use blk_archive::dump_stream;
 use blk_archive::list;
@@ -184,6 +185,11 @@ fn main_() -> Result<()> {
                 .about("lists the streams in the archive")
                 .arg(archive_arg.clone()),
         )
+        .subcommand(
+            Command::new("verify-all")
+                .about("verifies the integrity of the archive")
+                .arg(archive_arg.clone()),
+        )
         .get_matches();
 
     let report = mk_report(&matches);
@@ -210,6 +216,9 @@ fn main_() -> Result<()> {
         }
         Some(("dump-stream", sub_matches)) => {
             dump_stream::run(sub_matches, output)?;
+        }
+        Some(("verify-all", sub_matches)) => {
+            check::run(sub_matches, output)?;
         }
         _ => unreachable!("Exhausted list of subcommands and subcommand_required prevents 'None'"),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,14 @@ fn main_() -> Result<()> {
         .value_name("JSON")
         .takes_value(false);
 
+    let repair: Arg = Arg::new("REPAIR")
+        .help("repairs an archive")
+        .required(false)
+        .long("repair")
+        .short('r')
+        .value_name("REPAIR")
+        .takes_value(false);
+
     let matches = command!()
         .arg(json)
         .propagate_version(true)
@@ -188,7 +196,8 @@ fn main_() -> Result<()> {
         .subcommand(
             Command::new("verify-all")
                 .about("verifies the integrity of the archive")
-                .arg(archive_arg.clone()),
+                .arg(archive_arg.clone())
+                .arg(repair.clone()),
         )
         .get_matches();
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Context, Result};
-use byteorder::{LittleEndian, ReadBytesExt};
 use chrono::prelude::*;
 use clap::ArgMatches;
 use io::Write;
@@ -12,7 +11,6 @@ use std::boxed::Box;
 use std::env;
 use std::fs::OpenOptions;
 use std::io;
-use std::io::Cursor;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -162,10 +160,7 @@ impl DedupHandler {
             let buf = hashes_file.read(s as u32)?;
             let hi = ByHash::new(buf)?;
             for i in 0..hi.len() {
-                let h = hi.get(i);
-                let mini_hash = hash_64(&h[..]);
-                let mut c = Cursor::new(&mini_hash);
-                let mini_hash = c.read_u64::<LittleEndian>()?;
+                let (_, mini_hash) = hash_256_hash_64(hi.get(i));
                 seen.test_and_set(mini_hash, s as u32)?;
             }
         }
@@ -285,11 +280,7 @@ impl IoVecHandler for DedupHandler {
             )?;
             self.maybe_complete_stream()?;
         } else {
-            let h = hash_256_iov(iov);
-            let mini_hash = hash_64(&h);
-            let mut c = Cursor::new(&mini_hash);
-            let mini_hash = c.read_u64::<LittleEndian>()?;
-
+            let (h, mini_hash) = hash_256_hash_64_iov(iov);
             let me: MapEntry;
             match self.seen.test_and_set(mini_hash, self.current_slab)? {
                 InsertResult::Inserted => {

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -735,6 +735,8 @@ pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     env::set_current_dir(archive_dir)?;
     let config = config::read_config(".")?;
 
+    CheckPoint::interrupted()?;
+
     output
         .report
         .set_title(&format!("Building packer {} ...", input_file.display()));

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -228,6 +228,12 @@ fn writer_(shared: Arc<Mutex<SlabShared>>, rx: Receiver<SlabData>) -> Result<()>
     }
 
     assert!(queued.is_empty());
+
+    {
+        let mut shared = shared.lock().unwrap();
+        shared.data.flush()?;
+    }
+
     Ok(())
 }
 

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -86,7 +86,7 @@ impl SlabOffsets {
             if file_mtime > mtime {
                 return Err(anyhow!(
                     "Offsets file modification time is older than slab data file \
-                    run blk-archive 'verify-all --repair' to correct!",
+                    run blk-archive 'validate --repair all' to correct!",
                 ));
             }
         }
@@ -541,7 +541,7 @@ impl SlabFile {
         } else if data_mtime > offsets_mtime {
             Err(anyhow!(
                 "Offsets file modification time is older than slab data file \
-                run blk-archive 'verify-all --repair' to correct!",
+                run blk-archive 'validate --repair all' to correct!",
             ))
         } else {
             Ok(actual_count)

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 use thinp::report::*;
 
+use crate::check::*;
 use crate::chunkers::*;
 use crate::config;
 use crate::hash_index::*;
@@ -442,6 +443,9 @@ pub fn run_unpack(matches: &ArgMatches, report: Arc<Report>) -> Result<()> {
     let stream = matches.value_of("STREAM").unwrap();
     let create = matches.is_present("CREATE");
 
+    env::set_current_dir(archive_dir)?;
+    CheckPoint::interrupted()?;
+
     let output = if create {
         fs::OpenOptions::new()
             .read(false)
@@ -456,7 +460,6 @@ pub fn run_unpack(matches: &ArgMatches, report: Arc<Report>) -> Result<()> {
             .open(output_file)
             .context("Couldn't open output")?
     };
-    env::set_current_dir(archive_dir)?;
 
     report.set_title(&format!("Unpacking {} ...", output_file.display()));
     if create {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,13 @@
+#[macro_export]
+macro_rules! tpln {
+    () => {
+        print!("\n")
+    };
+    ($($arg:tt)*) => {{
+        println!("{:?}[{}:{}] {}", ::std::thread::current().id(), file!(), line!(), format!($($arg)*));
+    }};
+}
+
 pub fn round_pow2(i: u32) -> u64 {
     // Round up to the next power of 2
     // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2


### PR DESCRIPTION
Initial take at providing away to put an archive back into good state if a pack operation gets interrupted.

From git commit 280131e
```
The most important objective is to prevent the data slab and hashes slab from
getting corrupted and losing archived data.  Incomplete writes during a pack to
the slabs should be the only way for the slabs to get in an inconsistent state.
To allow us to detect and correct this we introduce a check point file at the
root of the archive which is written and sync'd to stable storage before we
start the pack operation.  This way if the pack operation is interrupted, we
can put the slab files back to where they were before we started with a repair
option.  Moving forward, the idea is we add the ability to periodically update
the checkpoint for long running operations by quiescing IO to the data slab,
hashes slab, offsets files, and the stream output and recording the offset into
the input data.  Then we can resume the operation by checking the files,
truncating where needed, and then resuming the de-dupe operation.

Note: If the slab file and the hashes file have no corruption and the
number of slabs match between the data and hash slab, the slab files are not
touched!  Thus the archive size could be much larger than would be
indicated by the listing of the archive as the data for the interrupted
pack operation is retained, but the stream is not.
```

I guess I could add a statement that the archive could get corrupted from bitrot, but that will be addressed in a future change where we introduce erasure coding support or similar.