### PR TITLE
Use yaml instead of toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,11 +79,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -138,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blake2"
@@ -173,13 +174,12 @@ dependencies = [
  "rand_chacha",
  "roaring",
  "serde",
- "serde_derive",
  "serde_json",
+ "serde_yaml",
  "size-display",
  "thinp",
  "threadpool",
- "toml",
- "udev 0.9.1",
+ "udev 0.9.3",
  "walkdir",
  "zstd",
 ]
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
@@ -213,9 +213,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -276,18 +276,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "devicemapper"
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "devicemapper"
 version = "0.34.4"
-source = "git+https://github.com/stratis-storage/devicemapper-rs?branch=master#06c303752d91a1789df9266a077f88f8a530a39a"
+source = "git+https://github.com/stratis-storage/devicemapper-rs?branch=master#de0fa322136b772e6cf4fb71afd40fd789d126a4"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "devicemapper-sys"
 version = "0.3.1"
-source = "git+https://github.com/stratis-storage/devicemapper-rs?branch=master#06c303752d91a1789df9266a077f88f8a530a39a"
+source = "git+https://github.com/stratis-storage/devicemapper-rs?branch=master#de0fa322136b772e6cf4fb71afd40fd789d126a4"
 dependencies = [
  "bindgen",
  "pkg-config",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
@@ -736,9 +736,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -851,12 +851,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit",
 ]
 
 [[package]]
@@ -990,9 +989,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safemem"
@@ -1011,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -1037,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -1048,12 +1047,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
  "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1154,36 +1157,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.22",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
 
 [[package]]
 name = "toml_edit"
@@ -1192,10 +1169,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "winnow 0.6.24",
+ "winnow",
 ]
 
 [[package]]
@@ -1217,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "udev"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d5c197b95f1769931c89f85c33c407801d1fb7a311113bc0b39ad036f1bd81"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
 dependencies = [
  "io-lifetimes",
  "libc",
@@ -1229,15 +1204,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -1516,18 +1497,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,12 @@ num_enum = "0.7.3"
 rand = "0.8"
 rand_chacha = "0.3"
 roaring = "0.10.10"
-serde = "1.0.136"
-serde_derive = "1.0.136"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 size-display = "0.1.4"
 thinp = { git = "https://github.com/jthornber/thin-provisioning-tools.git", branch = "main" }
 # thinp = { path = "../thinp-for-dm-archive/" }
 threadpool = "1.0"
-toml = "0.8.19"
 udev = "0.9.1"
 walkdir = "2"
 zstd = "0.13.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use chrono::prelude::*;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -20,19 +20,19 @@ pub struct Config {
 pub fn read_config<P: AsRef<Path>>(root: P) -> Result<Config> {
     let mut p = PathBuf::new();
     p.push(root);
-    p.push("dm-archive.toml");
+    p.push("dm-archive.yaml");
     let input = fs::read_to_string(p).context("couldn't read config file")?;
-    let config: Config = toml::from_str(&input).context("couldn't parse config file")?;
+    let config: Config = serde_yaml::from_str(&input).context("couldn't parse config file")?;
     Ok(config)
 }
 
 //-----------------------------------------
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct StreamConfig {
     pub name: Option<String>,
     pub source_path: String,
-    pub pack_time: toml::value::Datetime,
+    pub pack_time: String,
     pub size: u64,
     pub mapped_size: u64,
     pub packed_size: u64,
@@ -44,7 +44,7 @@ pub fn read_stream_config(stream_id: &str) -> Result<StreamConfig> {
     let input =
         fs::read_to_string(&p).with_context(|| format!("couldn't read stream config '{:?}", &p))?;
     let config: StreamConfig =
-        toml::from_str(&input).context("couldn't parse stream config file")?;
+        serde_yaml::from_str(&input).context("couldn't parse stream config file")?;
     Ok(config)
 }
 
@@ -55,19 +55,41 @@ pub fn write_stream_config(stream_id: &str, cfg: &StreamConfig) -> Result<()> {
         .write(true)
         .create(true)
         .open(p)?;
-    let toml = toml::to_string(cfg).unwrap();
-    output.write_all(toml.as_bytes())?;
+    let yaml = serde_yaml::to_string(cfg).unwrap();
+    output.write_all(yaml.as_bytes())?;
     Ok(())
 }
 
-pub fn now() -> toml::value::Datetime {
+pub fn now() -> String {
     let dt = Utc::now();
-    let str = dt.to_rfc3339();
-    str.parse::<toml::value::Datetime>().unwrap()
+    dt.to_rfc3339()
 }
 
-pub fn to_date_time(t: &toml::value::Datetime) -> chrono::DateTime<FixedOffset> {
-    DateTime::parse_from_rfc3339(&t.to_string()).unwrap()
+pub fn to_date_time(t: &str) -> chrono::DateTime<FixedOffset> {
+    DateTime::parse_from_rfc3339(t).unwrap()
 }
 
 //-----------------------------------------
+
+#[cfg(test)]
+mod config_tests {
+
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        let config = StreamConfig {
+            name: Some(String::from("test_file")),
+            source_path: String::from("/home/some_user/test_file"),
+            pack_time: String::from("2023-11-14T22:06:02.101221624+00:00"),
+            size: u64::MAX,
+            mapped_size: u64::MAX,
+            packed_size: u64::MAX,
+            thin_id: None,
+        };
+
+        let ser = serde_yaml::to_string(&config).unwrap();
+        let des_config: StreamConfig = serde_yaml::from_str(&ser).unwrap();
+        assert!(config == des_config);
+    }
+}

--- a/src/create.rs
+++ b/src/create.rs
@@ -31,7 +31,7 @@ fn write_config(
 ) -> Result<()> {
     let mut p = PathBuf::new();
     p.push(root);
-    p.push("dm-archive.toml");
+    p.push("dm-archive.yaml");
 
     let mut output = OpenOptions::new()
         .read(false)
@@ -47,7 +47,7 @@ fn write_config(
         data_cache_size_meg,
     };
 
-    write!(output, "{}", &toml::to_string(&config).unwrap())?;
+    write!(output, "{}", &serde_yaml::to_string(&config).unwrap())?;
     Ok(())
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -19,7 +19,7 @@ pub fn stream_path(stream: &str) -> PathBuf {
 }
 
 pub fn stream_config(stream: &str) -> PathBuf {
-    ["streams", stream, "config.toml"].iter().collect()
+    ["streams", stream, "config.yaml"].iter().collect()
 }
 
 //------------------------------


### PR DESCRIPTION
The toml serialization implementation does not handle u64 data types, yaml does, and it also handles u128.

Resolves: https://github.com/jthornber/blk-archive/issues/14