### PR TITLE
Introduce an abstraction for data slab handling

### DIFF
--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -30,7 +30,7 @@ impl Default for Bucket {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum InsertResult {
     PossiblyPresent(u32),
     Inserted,
@@ -262,6 +262,23 @@ impl CuckooFilter {
         }
 
         Err(anyhow!("cuckoo table full"))
+    }
+
+    pub fn test(&mut self, h: u64) -> Result<InsertResult> {
+        use InsertResult::*;
+
+        let fingerprint: u16 = (h & 0xffff) as u16;
+        let index1: usize = ((h >> 16) as usize) & self.mask;
+
+        if let Some(s) = self.present(fingerprint, index1) {
+            return Ok(PossiblyPresent(s));
+        }
+
+        let index2: usize = (index1 ^ self.scatter[fingerprint as usize]) & self.mask;
+        if let Some(s) = self.present(fingerprint, index2) {
+            return Ok(PossiblyPresent(s));
+        }
+        Ok(Inserted)
     }
 
     pub fn test_and_set(&mut self, h: u64, slab: u32) -> Result<InsertResult> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,268 @@
+use anyhow::Result;
+
+use crate::cuckoo_filter::*;
+use crate::hash::*;
+use crate::hash_index::*;
+use crate::iovec::*;
+use crate::paths;
+use crate::slab::*;
+use std::io::Write;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+pub const SLAB_SIZE_TARGET: usize = 4 * 1024 * 1024;
+
+pub struct Db {
+    seen: CuckooFilter,
+    hashes: lru::LruCache<u32, ByHash>,
+
+    data_file: SlabFile,
+    hashes_file: Arc<Mutex<SlabFile>>,
+
+    current_slab: u32,
+    current_entries: usize,
+    current_index: IndexBuilder,
+
+    data_buf: Vec<u8>,
+    hashes_buf: Vec<u8>,
+
+    slabs: lru::LruCache<u32, ByIndex>,
+}
+
+fn complete_slab_(slab: &mut SlabFile, buf: &mut Vec<u8>) -> Result<()> {
+    slab.write_slab(buf)?;
+    buf.clear();
+    Ok(())
+}
+
+pub fn complete_slab(slab: &mut SlabFile, buf: &mut Vec<u8>, threshold: usize) -> Result<bool> {
+    if buf.len() > threshold {
+        complete_slab_(slab, buf)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+impl Db {
+    pub fn new(
+        data_file: SlabFile,
+        hashes_file: Arc<Mutex<SlabFile>>,
+        slab_capacity: usize,
+    ) -> Result<Self> {
+        let seen = CuckooFilter::read(paths::index_path())?;
+        let hashes = lru::LruCache::new(NonZeroUsize::new(slab_capacity).unwrap());
+        let nr_slabs = data_file.get_nr_slabs() as u32;
+
+        {
+            let hashes_file = hashes_file.lock().unwrap();
+            assert_eq!(data_file.get_nr_slabs(), hashes_file.get_nr_slabs());
+        }
+
+        let slabs = lru::LruCache::new(NonZeroUsize::new(slab_capacity).unwrap());
+
+        Ok(Self {
+            seen,
+            hashes,
+            data_file,
+            hashes_file,
+            current_slab: nr_slabs,
+            current_index: IndexBuilder::with_capacity(1024), // FIXME: estimate
+            current_entries: 0,
+            data_buf: Vec::new(),
+            hashes_buf: Vec::new(),
+            slabs,
+        })
+    }
+
+    fn get_info(&mut self, slab: u32) -> Result<&ByIndex> {
+        self.slabs.try_get_or_insert(slab, || {
+            let mut hf = self.hashes_file.lock().unwrap();
+            let hashes = hf.read(slab)?;
+            ByIndex::new(hashes)
+        })
+    }
+
+    pub fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()> {
+        if self.seen.capacity() < self.seen.len() + blocks {
+            self.rebuild_index(self.seen.len() + blocks)?;
+            eprintln!("resized index to {}", self.seen.capacity());
+        }
+
+        Ok(())
+    }
+
+    fn get_hash_index(&mut self, slab: u32) -> Result<&ByHash> {
+        // the current slab is not inserted into the self.hashes
+        assert!(slab != self.current_slab);
+
+        self.hashes.try_get_or_insert(slab, || {
+            let mut hashes_file = self.hashes_file.lock().unwrap();
+            let buf = hashes_file.read(slab)?;
+            ByHash::new(buf)
+        })
+    }
+
+    fn rebuild_index(&mut self, new_capacity: usize) -> Result<()> {
+        let mut seen = CuckooFilter::with_capacity(new_capacity);
+
+        // Scan the hashes file.
+        let mut hashes_file = self.hashes_file.lock().unwrap();
+        let nr_slabs = hashes_file.get_nr_slabs();
+        for s in 0..nr_slabs {
+            let buf = hashes_file.read(s as u32)?;
+            let hi = ByHash::new(buf)?;
+            for i in 0..hi.len() {
+                let h = hi.get(i);
+                let mini_hash = hash_le_u64(h);
+                seen.test_and_set(mini_hash, s as u32)?;
+            }
+        }
+
+        std::mem::swap(&mut seen, &mut self.seen);
+
+        Ok(())
+    }
+
+    fn maybe_complete_data(&mut self, target: usize) -> Result<()> {
+        if complete_slab(&mut self.data_file, &mut self.data_buf, target)? {
+            let mut builder = IndexBuilder::with_capacity(1024); // FIXME: estimate properly
+            std::mem::swap(&mut builder, &mut self.current_index);
+            let buffer = builder.build()?;
+            self.hashes_buf.write_all(&buffer[..])?;
+            let index = ByHash::new(buffer)?;
+            self.hashes.put(self.current_slab, index);
+
+            let mut hashes_file = self.hashes_file.lock().unwrap();
+            complete_slab_(&mut hashes_file, &mut self.hashes_buf)?;
+            self.current_slab += 1;
+            self.current_entries = 0;
+        }
+        Ok(())
+    }
+
+    // Returns the (slab, entry) for the IoVec which may/may not already exist.
+    pub fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<(u32, u32)> {
+        // There is an inherent race condition between checking if we have it and adding it,
+        // check before we add when this functionality ends up on a server side.
+        if let Some(location) = self.is_known(&h)? {
+            return Ok(location);
+        }
+
+        // Add entry to cuckoo filter, not checking return value as we could get an "PossiblyPresent"
+        // when its not really present.  Cuckoo filters have the following behavior which is
+        // "possibly in set" or "definitely not in set"
+        //
+        self.seen.test_and_set(hash_le_u64(&h), self.current_slab)?;
+
+        let r = (self.current_slab, self.current_entries as u32);
+        for v in iov {
+            self.data_buf.extend_from_slice(v);
+        }
+        self.current_entries += 1;
+        self.current_index.insert(h, len as usize);
+        self.maybe_complete_data(SLAB_SIZE_TARGET)?;
+        Ok(r)
+    }
+
+    // Have we seen this hash before, if we have we will return the slab and offset
+    // Note: This function does not modify any state
+    pub fn is_known(&mut self, h: &Hash256) -> Result<Option<(u32, u32)>> {
+        let mini_hash = hash_le_u64(h);
+        let rc = match self.seen.test(mini_hash)? {
+            // This is a possibly in set
+            InsertResult::PossiblyPresent(s) => {
+                if self.current_slab == s {
+                    if let Some(offset) = self.current_index.lookup(h) {
+                        Some((self.current_slab, offset))
+                    } else {
+                        None
+                    }
+                } else {
+                    let hi = self.get_hash_index(s)?;
+                    hi.lookup(h).map(|offset| (s, offset as u32))
+                }
+            }
+            _ => None,
+        };
+        Ok(rc)
+    }
+
+    // NOTE: This won't work for multiple clients and one server!
+    pub fn file_sizes(&mut self) -> (u64, u64) {
+        let hashes_written = {
+            let hashes_file = self.hashes_file.lock().unwrap();
+            hashes_file.get_file_size()
+        };
+
+        (self.data_file.get_file_size(), hashes_written)
+    }
+
+    fn calculate_offsets(
+        offset: u32,
+        nr_entries: u32,
+        info: &ByIndex,
+        partial: Option<(u32, u32)>,
+    ) -> (usize, usize) {
+        let (data_begin, data_end) = if nr_entries == 1 {
+            let (data_begin, data_end, _expected_hash) = info.get(offset as usize).unwrap();
+            (*data_begin as usize, *data_end as usize)
+        } else {
+            let (data_begin, _data_end, _expected_hash) = info.get(offset as usize).unwrap();
+            let (_data_begin, data_end, _expected_hash) = info
+                .get((offset as usize) + (nr_entries as usize) - 1)
+                .unwrap();
+            (*data_begin as usize, *data_end as usize)
+        };
+
+        if let Some((begin, end)) = partial {
+            let data_end = data_begin + end as usize;
+            let data_begin = data_begin + begin as usize;
+            (data_begin, data_end)
+        } else {
+            (data_begin, data_end)
+        }
+    }
+
+    pub fn data_get(
+        &mut self,
+        slab: u32,
+        offset: u32,
+        nr_entries: u32,
+        partial: Option<(u32, u32)>,
+    ) -> Result<(Arc<Vec<u8>>, usize, usize)> {
+        let info = self.get_info(slab)?;
+        let (data_begin, data_end) = Self::calculate_offsets(offset, nr_entries, info, partial);
+        let data = self.data_file.read(slab)?;
+
+        Ok((data, data_begin, data_end))
+    }
+
+    // Not used at the moment, but was used for the send/receive POC.  This was being called after
+    // we received the newly created stream file for a pack operation.  The reason this is done is
+    // until you complete a slab, you cannot locate it in the data_get path for unpack operation.
+    pub fn complete_slab(&mut self) -> Result<()> {
+        self.maybe_complete_data(0)
+    }
+
+    fn sync_and_close(&mut self) {
+        self.maybe_complete_data(0)
+            .expect("db.drop: maybe_complete_data error!");
+        let mut hashes_file = self.hashes_file.lock().unwrap();
+        hashes_file
+            .close()
+            .expect("db.drop: hashes_file.close() error!");
+        self.data_file
+            .close()
+            .expect("db.drop: data_file.close() error!");
+        self.seen
+            .write(paths::index_path())
+            .expect("db.drop: seen.write() error!");
+    }
+}
+
+impl Drop for Db {
+    fn drop(&mut self) {
+        self.sync_and_close();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod content_sensitive_splitter;
 pub mod create;
 pub mod cuckoo_filter;
+pub mod db;
 pub mod dump_stream;
 pub mod hash;
 pub mod hash_index;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::prelude::*;
 use clap::ArgMatches;
-use io::Write;
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 use serde_json::json;
@@ -10,20 +9,16 @@ use size_display::Size;
 use std::boxed::Box;
 use std::env;
 use std::fs::OpenOptions;
-use std::io;
-use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use crate::chunkers::*;
 use crate::config;
 use crate::content_sensitive_splitter::*;
-use crate::cuckoo_filter::*;
+use crate::db::*;
 use crate::hash::*;
-use crate::hash_index::*;
 use crate::iovec::*;
 use crate::output::Output;
-use crate::paths;
 use crate::paths::*;
 use crate::run_iter::*;
 use crate::slab::*;
@@ -68,24 +63,10 @@ fn all_same(iov: &IoVec) -> Option<u8> {
 
 //-----------------------------------------
 
-pub const SLAB_SIZE_TARGET: usize = 4 * 1024 * 1024;
-
 struct DedupHandler {
     nr_chunks: usize,
 
-    seen: CuckooFilter,
-    hashes: lru::LruCache<u32, ByHash>,
-
-    data_file: SlabFile,
-    hashes_file: Arc<Mutex<SlabFile>>,
     stream_file: SlabFile,
-
-    current_slab: u32,
-    current_entries: usize,
-    current_index: IndexBuilder,
-
-    data_buf: Vec<u8>,
-    hashes_buf: Vec<u8>,
     stream_buf: Vec<u8>,
 
     mapping_builder: Arc<Mutex<dyn Builder>>,
@@ -93,127 +74,30 @@ struct DedupHandler {
     data_written: u64,
     mapped_size: u64,
     fill_size: u64,
+    db: Db,
 }
 
 impl DedupHandler {
-    fn get_hash_index(&mut self, slab: u32) -> Result<&ByHash> {
-        // the current slab is not inserted into the self.hashes
-        assert!(slab != self.current_slab);
-
-        self.hashes.try_get_or_insert(slab, || {
-            let mut hashes_file = self.hashes_file.lock().unwrap();
-            let buf = hashes_file.read(slab)?;
-            ByHash::new(buf)
-        })
-    }
-
     fn new(
-        data_file: SlabFile,
-        hashes_file: Arc<Mutex<SlabFile>>,
         stream_file: SlabFile,
-        slab_capacity: usize,
         mapping_builder: Arc<Mutex<dyn Builder>>,
+        db: Db,
     ) -> Result<Self> {
-        let seen = CuckooFilter::read(paths::index_path())?;
-        let hashes = lru::LruCache::new(NonZeroUsize::new(slab_capacity).unwrap());
-        let nr_slabs = data_file.get_nr_slabs() as u32;
-
-        {
-            let hashes_file = hashes_file.lock().unwrap();
-            assert_eq!(data_file.get_nr_slabs(), hashes_file.get_nr_slabs());
-        }
-
         Ok(Self {
             nr_chunks: 0,
-
-            seen,
-            hashes,
-
-            data_file,
-            hashes_file,
             stream_file,
-
-            current_slab: nr_slabs,
-            current_entries: 0,
-            current_index: IndexBuilder::with_capacity(1024), // FIXME: estimate
-
-            data_buf: Vec::new(),
-            hashes_buf: Vec::new(),
             stream_buf: Vec::new(),
-
             mapping_builder,
-
             // Stats
             data_written: 0,
             mapped_size: 0,
             fill_size: 0,
+            db,
         })
     }
 
-    fn rebuild_index(&mut self, new_capacity: usize) -> Result<()> {
-        let mut seen = CuckooFilter::with_capacity(new_capacity);
-
-        // Scan the hashes file.
-        let mut hashes_file = self.hashes_file.lock().unwrap();
-        let nr_slabs = hashes_file.get_nr_slabs();
-        for s in 0..nr_slabs {
-            let buf = hashes_file.read(s as u32)?;
-            let hi = ByHash::new(buf)?;
-            for i in 0..hi.len() {
-                let h = hi.get(i);
-                let mini_hash = hash_le_u64(h);
-                seen.test_and_set(mini_hash, s as u32)?;
-            }
-        }
-
-        std::mem::swap(&mut seen, &mut self.seen);
-
-        Ok(())
-    }
-
-    fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()> {
-        if self.seen.capacity() < self.seen.len() + blocks {
-            self.rebuild_index(self.seen.len() + blocks)?;
-            eprintln!("resized index to {}", self.seen.capacity());
-        }
-
-        Ok(())
-    }
-
-    fn complete_slab_(slab: &mut SlabFile, buf: &mut Vec<u8>) -> Result<()> {
-        slab.write_slab(buf)?;
-        buf.clear();
-        Ok(())
-    }
-
-    fn complete_slab(slab: &mut SlabFile, buf: &mut Vec<u8>, threshold: usize) -> Result<bool> {
-        if buf.len() > threshold {
-            Self::complete_slab_(slab, buf)?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn maybe_complete_data(&mut self, target: usize) -> Result<()> {
-        if Self::complete_slab(&mut self.data_file, &mut self.data_buf, target)? {
-            let mut builder = IndexBuilder::with_capacity(1024); // FIXME: estimate properly
-            std::mem::swap(&mut builder, &mut self.current_index);
-            let buffer = builder.build()?;
-            self.hashes_buf.write_all(&buffer[..])?;
-            let index = ByHash::new(buffer)?;
-            self.hashes.put(self.current_slab, index);
-
-            let mut hashes_file = self.hashes_file.lock().unwrap();
-            Self::complete_slab_(&mut hashes_file, &mut self.hashes_buf)?;
-            self.current_slab += 1;
-            self.current_entries = 0;
-        }
-        Ok(())
-    }
-
     fn maybe_complete_stream(&mut self) -> Result<()> {
-        Self::complete_slab(
+        complete_slab(
             &mut self.stream_file,
             &mut self.stream_buf,
             SLAB_SIZE_TARGET,
@@ -221,32 +105,9 @@ impl DedupHandler {
         Ok(())
     }
 
-    // Returns the (slab, entry) for the newly added entry
-    fn add_data_entry(&mut self, iov: &IoVec) -> Result<(u32, u32)> {
-        let r = (self.current_slab, self.current_entries as u32);
-        for v in iov {
-            self.data_buf.extend_from_slice(v);
-            self.data_written += v.len() as u64;
-        }
-        self.current_entries += 1;
-        Ok(r)
-    }
-
     fn add_stream_entry(&mut self, e: &MapEntry, len: u64) -> Result<()> {
         let mut builder = self.mapping_builder.lock().unwrap();
         builder.next(e, len, &mut self.stream_buf)
-    }
-
-    fn do_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<MapEntry> {
-        let (slab, offset) = self.add_data_entry(iov)?;
-        let me = MapEntry::Data {
-            slab,
-            offset,
-            nr_entries: 1,
-        };
-        self.current_index.insert(h, len as usize);
-        self.maybe_complete_data(SLAB_SIZE_TARGET)?;
-        Ok(me)
     }
 
     fn handle_gap(&mut self, len: u64) -> Result<()> {
@@ -261,6 +122,16 @@ impl DedupHandler {
         self.maybe_complete_stream()?;
 
         Ok(())
+    }
+
+    fn db_sizes(&mut self) -> (u64, u64) {
+        self.db.file_sizes()
+    }
+
+    // TODO: Is there a better way to handle this and what are the ramifications with
+    // client server with multiple clients and one server?
+    fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()> {
+        self.db.ensure_extra_capacity(blocks)
     }
 }
 
@@ -282,39 +153,14 @@ impl IoVecHandler for DedupHandler {
             self.maybe_complete_stream()?;
         } else {
             let h = hash_256_iov(iov);
-            let mini_hash = hash_le_u64(&h);
-
-            let me: MapEntry;
-            match self.seen.test_and_set(mini_hash, self.current_slab)? {
-                InsertResult::Inserted => {
-                    me = self.do_add(h, iov, len)?;
-                }
-                InsertResult::PossiblyPresent(s) => {
-                    if s == self.current_slab {
-                        if let Some(offset) = self.current_index.lookup(&h) {
-                            me = MapEntry::Data {
-                                slab: s,
-                                offset,
-                                nr_entries: 1,
-                            };
-                        } else {
-                            me = self.do_add(h, iov, len)?;
-                        }
-                    } else {
-                        let hi = self.get_hash_index(s)?;
-                        if let Some(offset) = hi.lookup(&h) {
-                            me = MapEntry::Data {
-                                slab: s,
-                                offset: offset as u32,
-                                nr_entries: 1,
-                            };
-                        } else {
-                            me = self.do_add(h, iov, len)?;
-                        }
-                    }
-                }
-            }
-
+            // Note: db.add_data_entry returns existing entry if present, else returns newly inserted
+            // entry.
+            let entry_location = self.db.data_add(h, iov, len)?;
+            let me = MapEntry::Data {
+                slab: entry_location.0,
+                offset: entry_location.1,
+                nr_entries: 1,
+            };
             self.add_stream_entry(&me, len)?;
             self.maybe_complete_stream()?;
         }
@@ -327,15 +173,8 @@ impl IoVecHandler for DedupHandler {
         builder.complete(&mut self.stream_buf)?;
         drop(builder);
 
-        self.maybe_complete_data(0)?;
-        Self::complete_slab(&mut self.stream_file, &mut self.stream_buf, 0)?;
-
-        let mut hashes_file = self.hashes_file.lock().unwrap();
-        hashes_file.close()?;
-        self.data_file.close()?;
+        complete_slab(&mut self.stream_file, &mut self.stream_buf, 0)?;
         self.stream_file.close()?;
-
-        self.seen.write(paths::index_path())?;
 
         Ok(())
     }
@@ -419,12 +258,6 @@ impl Packer {
             .queue_depth(128)
             .build()
             .context("couldn't open data slab file")?;
-        let data_size = data_file.get_file_size();
-
-        let hashes_size = {
-            let hashes_file = hashes_file.lock().unwrap();
-            hashes_file.get_file_size()
-        };
 
         let (stream_id, mut stream_path) = new_stream_path()?;
 
@@ -442,13 +275,12 @@ impl Packer {
             / std::mem::size_of::<Hash256>())
             / hashes_per_slab;
 
-        let mut handler = DedupHandler::new(
-            data_file,
-            hashes_file,
-            stream_file,
-            slab_capacity,
-            self.mapping_builder.clone(),
-        )?;
+        let db = Db::new(data_file, hashes_file, slab_capacity)?;
+
+        let mut handler = DedupHandler::new(stream_file, self.mapping_builder.clone(), db)?;
+
+        let start_sizes = handler.db_sizes();
+
         handler.ensure_extra_capacity(self.mapped_size as usize / self.block_size)?;
 
         self.output.report.progress(0);
@@ -482,12 +314,11 @@ impl Packer {
         let end_time: DateTime<Utc> = Utc::now();
         let elapsed = end_time - start_time;
         let elapsed = elapsed.num_milliseconds() as f64 / 1000.0;
-        let data_written = handler.data_file.get_file_size() - data_size;
 
-        let hashes_written = {
-            let hashes_file = handler.hashes_file.lock().unwrap();
-            hashes_file.get_file_size() - hashes_size
-        };
+        let end_sizes = handler.db_sizes();
+        let data_written = end_sizes.0 - start_sizes.0;
+        let hashes_written = end_sizes.1 - start_sizes.1;
+
         let stream_written = handler.stream_file.get_file_size();
         let ratio =
             (self.mapped_size as f64) / ((data_written + hashes_written + stream_written) as f64);

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -3,20 +3,19 @@ use chrono::prelude::*;
 use clap::ArgMatches;
 use io::{Read, Seek, Write};
 use size_display::Size;
-use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use thinp::report::*;
 
 use crate::chunkers::*;
 use crate::config;
-use crate::hash_index::*;
-use crate::pack::SLAB_SIZE_TARGET;
+use crate::db;
+use crate::db::SLAB_SIZE_TARGET;
 use crate::paths::*;
 use crate::run_iter::*;
 use crate::slab::*;
@@ -35,14 +34,8 @@ trait UnpackDest {
 }
 
 struct Unpacker<D: UnpackDest> {
-    data_file: SlabFile,
-    hashes_file: SlabFile,
     stream_file: SlabFile,
-
-    // FIXME: make this an lru cache
-    slabs: BTreeMap<u32, Arc<ByIndex>>,
-    partial: Option<(u32, u32)>,
-
+    db: db::Db,
     dest: D,
 }
 
@@ -52,39 +45,22 @@ impl<D: UnpackDest> Unpacker<D> {
         let data_file = SlabFileBuilder::open(data_path())
             .cache_nr_entries(cache_nr_entries)
             .build()?;
-        let hashes_file = SlabFileBuilder::open(hashes_path()).build()?;
+        let hashes_file = Arc::new(Mutex::new(
+            SlabFileBuilder::open(stream_path(stream)).build()?,
+        ));
         let stream_file = SlabFileBuilder::open(stream_path(stream)).build()?;
 
         Ok(Self {
-            data_file,
-            hashes_file,
             stream_file,
-            slabs: BTreeMap::new(),
-            partial: None,
+            db: db::Db::new(data_file, hashes_file, cache_nr_entries)?,
             dest,
         })
-    }
-
-    fn read_info(&mut self, slab: u32) -> Result<ByIndex> {
-        let hashes = self.hashes_file.read(slab)?;
-        ByIndex::new(hashes)
-    }
-
-    fn get_info(&mut self, slab: u32) -> Result<Arc<ByIndex>> {
-        if let Some(info) = self.slabs.get(&slab) {
-            Ok(info.clone())
-        } else {
-            let info = Arc::new(self.read_info(slab)?);
-            self.slabs.insert(slab, info.clone());
-            Ok(info)
-        }
     }
 
     fn unpack_entry(&mut self, e: &MapEntry) -> Result<()> {
         use MapEntry::*;
         match e {
             Fill { byte, len } => {
-                assert!(self.partial.is_none());
                 // len may be very big, so we have to be prepared to write in chunks.
                 // FIXME: if we're writing to a file would this be zeroes anyway?  fallocate?
                 const MAX_BUFFER: u64 = 16 * 1024 * 1024;
@@ -97,7 +73,6 @@ impl<D: UnpackDest> Unpacker<D> {
                 }
             }
             Unmapped { len } => {
-                assert!(self.partial.is_none());
                 self.dest.handle_unmapped(*len)?;
             }
             Data {
@@ -105,30 +80,8 @@ impl<D: UnpackDest> Unpacker<D> {
                 offset,
                 nr_entries,
             } => {
-                let info = self.get_info(*slab)?;
-
-                let (data_begin, data_end) = if *nr_entries == 1 {
-                    let (data_begin, data_end, _expected_hash) =
-                        info.get(*offset as usize).unwrap();
-                    (*data_begin as usize, *data_end as usize)
-                } else {
-                    let (data_begin, _data_end, _expected_hash) =
-                        info.get(*offset as usize).unwrap();
-                    let (_data_begin, data_end, _expected_hash) = info
-                        .get((*offset as usize) + (*nr_entries as usize) - 1)
-                        .unwrap();
-                    (*data_begin as usize, *data_end as usize)
-                };
-
-                let data = self.data_file.read(*slab)?;
-                if let Some((begin, end)) = self.partial {
-                    let data_end = data_begin + end as usize;
-                    let data_begin = data_begin + begin as usize;
-                    self.dest.handle_mapped(&data[data_begin..data_end])?;
-                    self.partial = None;
-                } else {
-                    self.dest.handle_mapped(&data[data_begin..data_end])?;
-                }
+                let (data, start, end) = self.db.data_get(*slab, *offset, *nr_entries, None)?;
+                self.dest.handle_mapped(&data[start..end])?;
             }
             Partial {
                 begin,
@@ -137,13 +90,9 @@ impl<D: UnpackDest> Unpacker<D> {
                 offset,
                 nr_entries,
             } => {
-                assert!(self.partial.is_none());
-                self.partial = Some((*begin, *end));
-                self.unpack_entry(&MapEntry::Data {
-                    slab: *slab,
-                    offset: *offset,
-                    nr_entries: *nr_entries,
-                })?;
+                let partial = Some((*begin, *end));
+                let (data, start, end) = self.db.data_get(*slab, *offset, *nr_entries, partial)?;
+                self.dest.handle_mapped(&data[start..end])?;
             }
             Ref { .. } => {
                 // Can't get here.


### PR DESCRIPTION
This change introduces an abstraction for pack and unpack operations. After creating an instance of Db, use data_add for packing and data_get for unpacking.

The Db struct encapsulates a Cuckoo filter and an LruCache for lookups during data_add, as well as a separate LruCache for data_get operations.