### PR TITLE
[cdc] Fix panic on verify

### DIFF
--- a/src/content_sensitive_splitter.rs
+++ b/src/content_sensitive_splitter.rs
@@ -68,7 +68,7 @@ impl ContentSensitiveSplitter {
             if blen == 0 {
                 c.offset = 0;
                 c.block += 1;
-            } else if blen >= remaining {
+            } else if blen > remaining {
                 r.push(&b[c.offset..(c.offset + remaining)]);
                 c.offset += remaining;
                 remaining = 0;
@@ -80,6 +80,11 @@ impl ContentSensitiveSplitter {
             }
         }
         self.unconsumed_len -= len as u64;
+
+        if self.unconsumed_len == 0 {
+            assert!(c.block == self.blocks.len());
+        }
+
         r
     }
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -140,6 +140,7 @@ impl IoVecHandler for DedupHandler {
         self.nr_chunks += 1;
         let len = iov_len_(iov);
         self.mapped_size += len;
+        assert!(len != 0);
 
         if let Some(first_byte) = all_same(iov) {
             self.fill_size += len;


### PR DESCRIPTION
When working on a new test case I can into the following panic

```
thread 'main' panicked at src/slab.rs:426:44:
index out of bounds: the len is 0 but the index is 0 stack backtrace:
   0: rust_begin_unwind
             at /builddir/build/BUILD/rust-1.84.1-build/rustc-1.84.1-src/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /builddir/build/BUILD/rust-1.84.1-build/rustc-1.84.1-src/library/core/src/panicking.rs:76:14
   2: core::panicking::panic_bounds_check
             at /builddir/build/BUILD/rust-1.84.1-build/rustc-1.84.1-src/library/core/src/panicking.rs:281:5
   3: <usize as core::slice::index::SliceIndex<[T]>>::index
             at /builddir/build/BUILD/rust-1.84.1-build/rustc-1.84.1-src/library/core/src/slice/index.rs:274:10
   4: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /builddir/build/BUILD/rust-1.84.1-build/rustc-1.84.1-src/library/core/src/slice/index.rs:16:15
   5: <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
             at /builddir/build/BUILD/rust-1.84.1-build/rustc-1.84.1-src/library/alloc/src/vec/mod.rs:3346:9
   6: blk_archive::slab::SlabFile::read_
             at /home/tasleson/projects/blk-archive/src/slab.rs:426:44
   7: blk_archive::slab::SlabFile::read
             at /home/tasleson/projects/blk-archive/src/slab.rs:460:33
   8: blk_archive::archive::Data::get_info::{{closure}}
             at /home/tasleson/projects/blk-archive/src/archive.rs:81:26
   9: lru::LruCache<K,V,S>::try_get_or_insert
             at /home/tasleson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lru-0.12.5/src/lib.rs:704:21
  10: blk_archive::archive::Data::get_info
             at /home/tasleson/projects/blk-archive/src/archive.rs:79:9
  11: blk_archive::archive::Data::data_get
             at /home/tasleson/projects/blk-archive/src/archive.rs:258:20
  12: blk_archive::unpack::Unpacker<D>::unpack_entry
             at /home/tasleson/projects/blk-archive/src/unpack.rs:83:21
  13: blk_archive::unpack::Unpacker<D>::unpack
             at /home/tasleson/projects/blk-archive/src/unpack.rs:122:17
  14: blk_archive::unpack::run_verify
             at /home/tasleson/projects/blk-archive/src/unpack.rs:630:5
  15: blk_archive::main_
             at /home/tasleson/projects/blk-archive/src/main.rs:198:13
  16: blk_archive::main
             at /home/tasleson/projects/blk-archive/src/main.rs:213:22
```

The input is a block device that is all zeros.  When I inspected the stream instructions I discovered.

```
0000000000      fill 1073741824 (0)
0000000001      emit 1           0:1 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0 0:0

Instruction frequencies:

             fill32 1
              emit4 1
                rot 0
                dup 0
           set-fill 0
              fill8 0
             fill16 0
             fill64 0
          unmapped8 0
         unmapped16 0
         unmapped32 0
         unmapped64 0
             slab16 0
             slab32 0
        slab_delta4 0
       slab_delta12 0
               next 0
            offset4 0
           offset12 0
           offset20 0
      offset_delta4 0
     offset_delta12 0
             emit12 0
             emit20 0
              pos32 0
              pos64 0
```

After digging into this I tracked it down to when consume_all gets called and the logic in the method was returning an IoVec with 1 empty byte slice. Thus when we were in the method 'complete' the iov.is_empty returned 'false' which caused us to call the handle_data with a zero length IoVec.

Root cause appears to be `consume` method of the ContentSensitiveSplitter not handling when `blen == remaining` and not incrementing c.block.

With this change things work as expected, including the instruction stream only including a single fill instruction.