### PR TITLE
Add additional tests for pack stats.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "size-display",
  "tempfile",
  "thinp",
@@ -1124,10 +1124,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8"
 rand_chacha = "0.3"
 roaring = "0.10.10"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 size-display = "0.1.4"
 thinp = { git = "https://github.com/jthornber/thin-provisioning-tools.git", branch = "main" }
 # thinp = { path = "../thinp-for-dm-archive/" }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -154,11 +154,11 @@ impl Data {
     }
 
     // Returns the (slab, entry) for the IoVec which may/may not already exist.
-    pub fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<((u32, u32), bool)> {
+    pub fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<((u32, u32), u64)> {
         // There is an inherent race condition between checking if we have it and adding it,
         // check before we add when this functionality ends up on a server side.
         if let Some(location) = self.is_known(&h)? {
-            return Ok((location, false));
+            return Ok((location, 0));
         }
 
         // Add entry to cuckoo filter, not checking return value as we could get indication that
@@ -180,7 +180,7 @@ impl Data {
         }
         self.current_entries += 1;
         self.current_index.insert(h, len as usize);
-        Ok((r, true))
+        Ok((r, len))
     }
 
     // Have we seen this hash before, if we have we will return the slab and offset
@@ -259,7 +259,7 @@ impl Data {
     // Not used at the moment, but was used for the send/receive POC.  This was being called after
     // we received the newly created stream file for a pack operation.  The reason this is done is
     // until you complete a slab, you cannot locate it in the data_get path for unpack operation.
-    pub fn complete_slab(&mut self) -> Result<()> {
+    pub fn flush(&mut self) -> Result<()> {
         self.complete_data_slab()
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,12 +34,12 @@ pub fn read_config<P: AsRef<Path>>(root: P, overrides: &ArgMatches) -> Result<Co
     p.push(root);
     p.push("dm-archive.yaml");
     let input = fs::read_to_string(p).context("couldn't read config file")?;
-    let mut config: Config = serde_yaml::from_str(&input).context("couldn't parse config file")?;
+    let mut config: Config =
+        serde_yaml_ng::from_str(&input).context("couldn't parse config file")?;
 
     if let Some(data_cache_meg) = numeric_override::<usize>(overrides, "DATA_CACHE_SIZE_MEG")? {
         config.data_cache_size_meg = data_cache_meg;
     }
-
     Ok(config)
 }
 
@@ -61,7 +61,7 @@ pub fn read_stream_config(stream_id: &str) -> Result<StreamConfig> {
     let input =
         fs::read_to_string(&p).with_context(|| format!("couldn't read stream config '{:?}", &p))?;
     let config: StreamConfig =
-        serde_yaml::from_str(&input).context("couldn't parse stream config file")?;
+        serde_yaml_ng::from_str(&input).context("couldn't parse stream config file")?;
     Ok(config)
 }
 
@@ -73,7 +73,7 @@ pub fn write_stream_config(stream_id: &str, cfg: &StreamConfig) -> Result<()> {
         .create(true)
         .truncate(true)
         .open(p)?;
-    let yaml = serde_yaml::to_string(cfg).unwrap();
+    let yaml = serde_yaml_ng::to_string(cfg).unwrap();
     output.write_all(yaml.as_bytes())?;
     Ok(())
 }
@@ -106,8 +106,8 @@ mod config_tests {
             thin_id: None,
         };
 
-        let ser = serde_yaml::to_string(&config).unwrap();
-        let des_config: StreamConfig = serde_yaml::from_str(&ser).unwrap();
+        let ser = serde_yaml_ng::to_string(&config).unwrap();
+        let des_config: StreamConfig = serde_yaml_ng::from_str(&ser).unwrap();
         assert!(config == des_config);
     }
 }

--- a/src/create.rs
+++ b/src/create.rs
@@ -88,6 +88,7 @@ fn numeric_option<T: std::str::FromStr>(matches: &ArgMatches, name: &str, dflt: 
 
 pub fn run(matches: &ArgMatches, report: Arc<Report>) -> Result<()> {
     let dir = Path::new(matches.get_one::<String>("ARCHIVE").unwrap());
+    let data_compression = matches.get_one::<String>("DATA_COMPRESSION").unwrap() == "y";
 
     let mut block_size = numeric_option::<usize>(matches, "BLOCK_SIZE", 4096)?;
     let new_block_size = adjust_block_size(block_size);
@@ -109,7 +110,7 @@ pub fn run(matches: &ArgMatches, report: Arc<Report>) -> Result<()> {
     // Create empty data and hash slab files
     let mut data_file = SlabFileBuilder::create(data_path())
         .queue_depth(1)
-        .compressed(true)
+        .compressed(data_compression)
         .build()?;
     data_file.close()?;
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -47,7 +47,7 @@ fn write_config(
         data_cache_size_meg,
     };
 
-    write!(output, "{}", &serde_yaml::to_string(&config).unwrap())?;
+    write!(output, "{}", &serde_yaml_ng::to_string(&config).unwrap())?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,10 +197,10 @@ fn main_() -> Result<()> {
             pack::run(sub_matches, output)?;
         }
         Some(("unpack", sub_matches)) => {
-            unpack::run_unpack(sub_matches, report)?;
+            unpack::run_unpack(sub_matches, output)?;
         }
         Some(("verify", sub_matches)) => {
-            unpack::run_verify(sub_matches, report)?;
+            unpack::run_verify(sub_matches, output)?;
         }
         Some(("list", sub_matches)) => {
             list::run(sub_matches, output)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,16 @@ fn main_() -> Result<()> {
                         .value_name("HASH_CACHE_SIZE_MEG")
                         .num_args(1),
                 )
-                .arg(data_cache_size.clone()),
+                .arg(data_cache_size.clone())
+                .arg(
+                    Arg::new("DATA_COMPRESSION")
+                        .long("data-compression")
+                        .value_name("y|n")
+                        .help("Enable or disable slab data compression")
+                        .value_parser(["y", "n"]) // Restrict values
+                        .default_value("y")
+                        .action(ArgAction::Set),
+                ),
         )
         .subcommand(
             Command::new("pack")

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -322,7 +322,7 @@ impl Packer {
         if self.output.json {
             // Should all the values simply be added to the json too?  We can always add entries, but
             // we can never take any away to maintains backwards compatibility with JSON consumers.
-            let result = json!({ "stream_id": stream_id });
+            let result = json!({ "stream_id": stream_id, "stats": handler.stats, });
             println!("{}", to_string_pretty(&result).unwrap());
         } else {
             self.output

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -63,6 +63,12 @@ fn all_same(iov: &IoVec) -> Option<u8> {
 }
 
 //-----------------------------------------
+#[derive(serde::Serialize, Default)]
+struct DedupStats {
+    data_written: u64,
+    mapped_size: u64,
+    fill_size: u64,
+}
 
 struct DedupHandler {
     nr_chunks: usize,
@@ -72,9 +78,7 @@ struct DedupHandler {
 
     mapping_builder: Arc<Mutex<dyn Builder>>,
 
-    data_written: u64,
-    mapped_size: u64,
-    fill_size: u64,
+    stats: DedupStats,
     archive: Data,
 }
 
@@ -84,15 +88,14 @@ impl DedupHandler {
         mapping_builder: Arc<Mutex<dyn Builder>>,
         archive: Data,
     ) -> Result<Self> {
+        let stats = DedupStats::default();
+
         Ok(Self {
             nr_chunks: 0,
             stream_file,
             stream_buf: Vec::new(),
             mapping_builder,
-            // Stats
-            data_written: 0,
-            mapped_size: 0,
-            fill_size: 0,
+            stats,
             archive,
         })
     }
@@ -125,10 +128,6 @@ impl DedupHandler {
         Ok(())
     }
 
-    fn archive_file_sizes(&mut self) -> (u64, u64) {
-        self.archive.file_sizes()
-    }
-
     // TODO: Is there a better way to handle this and what are the ramifications with
     // client server with multiple clients and one server?
     fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()> {
@@ -140,11 +139,11 @@ impl IoVecHandler for DedupHandler {
     fn handle_data(&mut self, iov: &IoVec) -> Result<()> {
         self.nr_chunks += 1;
         let len = iov_len_(iov);
-        self.mapped_size += len;
+        self.stats.mapped_size += len;
         assert!(len != 0);
 
         if let Some(first_byte) = all_same(iov) {
-            self.fill_size += len;
+            self.stats.fill_size += len;
             self.add_stream_entry(
                 &MapEntry::Fill {
                     byte: first_byte,
@@ -157,15 +156,13 @@ impl IoVecHandler for DedupHandler {
             let h = hash_256_iov(iov);
             // Note: add_data_entry returns existing entry if present, else returns newly inserted
             // entry.
-            let (entry_location, inserted) = self.archive.data_add(h, iov, len)?;
+            let (entry_location, data_written) = self.archive.data_add(h, iov, len)?;
             let me = MapEntry::Data {
                 slab: entry_location.0,
                 offset: entry_location.1,
                 nr_entries: 1,
             };
-            if inserted {
-                self.data_written += len;
-            }
+            self.stats.data_written += data_written;
             self.add_stream_entry(&me, len)?;
             self.maybe_complete_stream()?;
         }
@@ -284,8 +281,6 @@ impl Packer {
 
         let mut handler = DedupHandler::new(stream_file, self.mapping_builder.clone(), ad)?;
 
-        let start_sizes = handler.archive_file_sizes();
-
         handler.ensure_extra_capacity(self.mapped_size as usize / self.block_size)?;
 
         self.output.report.progress(0);
@@ -316,17 +311,13 @@ impl Packer {
 
         splitter.complete(&mut handler)?;
         self.output.report.progress(100);
+        handler.archive.flush()?;
         let end_time: DateTime<Utc> = Utc::now();
         let elapsed = end_time - start_time;
         let elapsed = elapsed.num_milliseconds() as f64 / 1000.0;
-
-        let end_sizes = handler.archive_file_sizes();
-        let data_written = end_sizes.0 - start_sizes.0;
-        let hashes_written = end_sizes.1 - start_sizes.1;
-
         let stream_written = handler.stream_file.get_file_size();
         let ratio =
-            (self.mapped_size as f64) / ((data_written + hashes_written + stream_written) as f64);
+            (self.mapped_size as f64) / ((handler.stats.data_written + stream_written) as f64);
 
         if self.output.json {
             // Should all the values simply be added to the json too?  We can always add entries, but
@@ -351,19 +342,17 @@ impl Packer {
                 .info(&format!("total read       : {:.2}", Size(total_read)));
             self.output.report.info(&format!(
                 "fills size       : {:.2}",
-                Size(handler.fill_size)
+                Size(handler.stats.fill_size)
             ));
             self.output.report.info(&format!(
                 "duplicate data   : {:.2}",
-                Size(total_read - handler.data_written - handler.fill_size)
+                Size(total_read - handler.stats.data_written - handler.stats.fill_size)
             ));
 
-            self.output
-                .report
-                .info(&format!("data written     : {:.2}", Size(data_written)));
-            self.output
-                .report
-                .info(&format!("hashes written   : {:.2}", Size(hashes_written)));
+            self.output.report.info(&format!(
+                "data written     : {:.2}",
+                Size(handler.stats.data_written)
+            ));
             self.output
                 .report
                 .info(&format!("stream written   : {:.2}", Size(stream_written)));
@@ -383,7 +372,7 @@ impl Packer {
             pack_time: config::now(),
             size: self.input_size,
             mapped_size: self.mapped_size,
-            packed_size: data_written + hashes_written + stream_written,
+            packed_size: handler.stats.data_written + stream_written,
             thin_id: self.thin_id,
         };
         config::write_stream_config(&stream_id, &cfg)?;

--- a/src/slab/file.rs
+++ b/src/slab/file.rs
@@ -34,6 +34,8 @@ const FORMAT_VERSION: u32 = 0;
 
 pub type SlabIndex = u64;
 
+pub const SLAB_META_SIZE: u64 = 24; // Slab magic + length + check sum, each of which is 8 bytes
+
 // Clone should only be used in tests
 #[derive(Clone)]
 pub struct SlabData {

--- a/test/vm_test.sh
+++ b/test/vm_test.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/bash
 
+echo "Kernel version"
+uname -a
+
+echo "Distro info"
+lsb_release -a
+
+START_DIR=$(pwd)
+
+echo "PWD $START_DIR"
+
+# Name of modules we need for ublk_drv (if we later want to use it!)
+K_PKG_NAME="linux-modules-extra-$(uname -r)"
+
 # Install all the dependencies
 export DEBIAN_FRONTEND="noninteractive"
 apt-get update -y || exit 1
 
-apt-get install git gcc clang-tools libdevmapper-dev pkg-config mount python3 python3-toml python3-pudb python3-numpy -y || exit 1
+apt-get install git gcc clang-tools libdevmapper-dev pkg-config mount python3 python3-toml python3-pudb python3-numpy "$K_PKG_NAME"  -y || exit 1
 
 # install rust via rustup as packages are too old on ubuntu
 curl https://sh.rustup.rs -sSf | sh -s -- -y || exit 1
@@ -12,12 +25,10 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y || exit 1
 # Get rust tools in path
 source "$HOME/.cargo/env" || exit 1
 
-cargo build || exit 1
+cargo build --release || exit 1
 
-# Run the rust tests
-cargo test || exit 1
-
-export PATH=$PATH:`pwd`/target/debug
+PATH=$PATH:$(pwd)/target/release
+export path
 
 if [ ! -d dmtest-python ]; then
     git clone https://github.com/jthornber/dmtest-python.git || exit 1
@@ -32,9 +43,13 @@ loop1=$(losetup -f --show /block1.img)
 loop2=$(losetup -f --show /block2.img)
 loop3=$(losetup -f --show /block3.img)
 
+# Run the cargo based tests
+cd "$START_DIR" || exit 1
+cargo test || exit 1
 
+# Run the dmtest-python tests for blk-archive
 # Unable to run rolling linux test as we don't have enough disk space in the CI VMs.
-
+cd "$START_DIR" || exit 1
 # setup the configuration file for dmtest-python
 cd dmtest-python || exit 1
 
@@ -42,8 +57,12 @@ echo "metadata_dev = '$loop1'" > config.toml
 echo "data_dev = '$loop2'" >> config.toml
 echo "disable_by_id_check = true" >> config.toml
 
-
 export DMTEST_RESULT_SET=unit-test
 ./dmtest health || exit 1
-./dmtest run blk-archive/unit/combinations || exit 1
-
+./dmtest run blk-archive/unit/combinations
+rc=$?
+if [ $rc -ne 0 ]; then
+    ./dmtest log /blk-archive/unit/combinations
+    exit 1
+fi
+exit 0

--- a/tests/common/block_visitor.rs
+++ b/tests/common/block_visitor.rs
@@ -4,7 +4,7 @@ use thinp::io_engine::buffer::Buffer;
 use thinp::io_engine::PAGE_SIZE;
 use thinp::math::div_up;
 
-use crate::common::random::Generator;
+use crate::common::random::{Generator, Pattern};
 
 //------------------------------------------
 
@@ -29,11 +29,13 @@ pub struct Stamper<T> {
     offset: u64,     // bytes
     len: u64,        // bytes
     size_limit: u64, // bytes
+    generator: Generator,
 }
 
 impl<T: FileExt> Stamper<T> {
-    pub fn new(file: T, seed: u64, block_size: usize) -> Self {
+    pub fn new(file: T, seed: u64, block_size: usize, pattern: Pattern) -> Self {
         let buf = Buffer::new(block_size, PAGE_SIZE);
+        let generator = Generator::new(pattern);
         Self {
             file,
             block_size,
@@ -42,6 +44,7 @@ impl<T: FileExt> Stamper<T> {
             offset: 0,
             len: u64::MAX,
             size_limit: u64::MAX,
+            generator,
         }
     }
 
@@ -67,9 +70,8 @@ impl<T: FileExt> BlockVisitor for Stamper<T> {
     fn visit(&mut self, blocknr: u64) -> Result<()> {
         let offset = blocknr * self.block_size as u64 + self.offset;
         if offset < self.size_limit {
-            let mut gen = Generator::new();
-            gen.fill_buffer(self.seed ^ blocknr, self.buf.get_data())?;
-
+            self.generator
+                .fill_buffer(self.seed ^ blocknr, self.buf.get_data())?;
             let len = std::cmp::min(self.block_size as u64, self.size_limit - offset);
             self.file
                 .write_all_at(&self.buf.get_data()[..len as usize], offset)?;
@@ -88,11 +90,13 @@ pub struct Verifier<T> {
     offset: u64,
     len: u64,
     size_limit: u64,
+    generator: Generator,
 }
 
 impl<T: FileExt> Verifier<T> {
-    pub fn new(file: T, seed: u64, block_size: usize) -> Self {
+    pub fn new(file: T, seed: u64, block_size: usize, pattern: Pattern) -> Self {
         let buf = Buffer::new(block_size, PAGE_SIZE);
+        let generator = Generator::new(pattern);
         Self {
             file,
             block_size,
@@ -101,6 +105,7 @@ impl<T: FileExt> Verifier<T> {
             offset: 0,
             len: u64::MAX,
             size_limit: u64::MAX,
+            generator,
         }
     }
 
@@ -130,12 +135,10 @@ impl<T: FileExt> BlockVisitor for Verifier<T> {
             let buf = &mut self.buf.get_data()[..len as usize];
             self.file.read_exact_at(buf, offset)?;
 
-            let mut gen = Generator::new();
-            if !gen.verify_buffer(self.seed ^ blocknr, buf)? {
+            if !self.generator.verify_buffer(self.seed ^ blocknr, buf)? {
                 return Err(anyhow!("data verify failed for data block {}", blocknr));
             }
         }
-
         Ok(())
     }
 }

--- a/tests/common/fixture.rs
+++ b/tests/common/fixture.rs
@@ -5,27 +5,32 @@ use thinp::file_utils::create_sized_file;
 
 use crate::common::blk_archive::*;
 use crate::common::block_visitor::*;
+use crate::common::random::Pattern;
 use crate::common::test_dir::*;
 
 //-----------------------------------------
 
-const BLOCK_SIZE: usize = 32768;
+pub const BLOCK_SIZE: usize = 32768;
 
-pub fn create_archive(td: &mut TestDir) -> Result<BlkArchive> {
+pub fn create_archive(td: &mut TestDir, data_compression: bool) -> Result<BlkArchive> {
     let archive_dir = td.mk_path("test_arch");
-    BlkArchive::new(&archive_dir)
+    BlkArchive::new_with(&archive_dir, 4096, data_compression)
 }
 
-// FIXME: generate dedupable data
-pub fn create_input_file(td: &mut TestDir, size: u64, seed: u64) -> Result<PathBuf> {
+pub fn create_input_file(
+    td: &mut TestDir,
+    size: u64,
+    seed: u64,
+    pattern: Pattern,
+) -> Result<PathBuf> {
     let path = td.mk_path("input.bin");
     let file = create_sized_file(&path, size)?;
-    let mut stamper = Stamper::new(file, seed, BLOCK_SIZE).len(size);
+    let mut stamper = Stamper::new(file, seed, BLOCK_SIZE, pattern).len(size);
     stamper.stamp_file()?;
     Ok(path)
 }
 
-pub fn verify_file(path: &Path, size: u64, seed: u64) -> Result<()> {
+pub fn verify_file(path: &Path, size: u64, seed: u64, pattern: Pattern) -> Result<()> {
     let actual_size = std::fs::metadata(path)?.len();
     if actual_size != size {
         return Err(anyhow!(
@@ -40,7 +45,7 @@ pub fn verify_file(path: &Path, size: u64, seed: u64) -> Result<()> {
         .write(false)
         .custom_flags(libc::O_EXCL)
         .open(path)?;
-    let mut verifier = Verifier::new(file, seed, BLOCK_SIZE).len(size);
+    let mut verifier = Verifier::new(file, seed, BLOCK_SIZE, pattern).len(size);
     verifier.verify()
 }
 

--- a/tests/common/random.rs
+++ b/tests/common/random.rs
@@ -4,20 +4,29 @@ use std::io::Cursor;
 
 //------------------------------------
 
+#[derive(Debug, Clone)]
+pub enum Pattern {
+    LCG,                // Linear Congruence Generator (default)
+    SingleByte(u8),     // Fill with a single byte value
+    Repeating(Vec<u8>), // Fill with a repeating byte pattern
+}
+
 // A simple linear congruence generator used to create the data to
 // go into the thin/cache blocks.
 pub struct Generator {
     x: u64,
     a: u64,
     c: u64,
+    pattern: Pattern,
 }
 
 impl Generator {
-    pub fn new() -> Generator {
+    pub fn new(pattern: Pattern) -> Generator {
         Generator {
             x: 0,
             a: 6364136223846793005,
             c: 1442695040888963407,
+            pattern,
         }
     }
 
@@ -26,43 +35,70 @@ impl Generator {
     }
 
     pub fn fill_buffer(&mut self, seed: u64, bytes: &mut [u8]) -> Result<()> {
-        self.x = seed;
+        match &self.pattern {
+            Pattern::LCG => {
+                self.x = seed;
+                assert!(bytes.len() % 8 == 0);
+                let nr_words = bytes.len() / 8;
+                let mut out = Cursor::new(bytes);
 
-        assert!(bytes.len() % 8 == 0);
-        let nr_words = bytes.len() / 8;
-        let mut out = Cursor::new(bytes);
-
-        for _ in 0..nr_words {
-            out.write_u64::<LittleEndian>(self.x)?;
-            self.step();
+                for _ in 0..nr_words {
+                    out.write_u64::<LittleEndian>(self.x)?;
+                    self.step();
+                }
+            }
+            Pattern::SingleByte(b) => {
+                bytes.fill(*b);
+            }
+            Pattern::Repeating(pattern) => {
+                let pat_len = pattern.len();
+                for (i, byte) in bytes.iter_mut().enumerate() {
+                    *byte = pattern[i % pat_len];
+                }
+            }
         }
-
         Ok(())
     }
 
     pub fn verify_buffer(&mut self, seed: u64, bytes: &[u8]) -> Result<bool> {
-        self.x = seed;
+        match &self.pattern {
+            Pattern::LCG => {
+                self.x = seed;
+                assert!(bytes.len() % 8 == 0);
+                let nr_words = bytes.len() / 8;
+                let mut input = Cursor::new(bytes);
 
-        assert!(bytes.len() % 8 == 0);
-        let nr_words = bytes.len() / 8;
-        let mut input = Cursor::new(bytes);
-
-        for _ in 0..nr_words {
-            let w = input.read_u64::<LittleEndian>()?;
-            if w != self.x {
-                eprintln!("{} != {}", w, self.x);
+                for _ in 0..nr_words {
+                    let w = input.read_u64::<LittleEndian>()?;
+                    if w != self.x {
+                        eprintln!("{} != {}", w, self.x);
+                        return Ok(false);
+                    }
+                    self.step();
+                }
+            }
+            Pattern::SingleByte(b) => {
+                if bytes.iter().all(|&byte| byte == *b) {
+                    return Ok(true);
+                }
                 return Ok(false);
             }
-            self.step();
+            Pattern::Repeating(pattern) => {
+                let pat_len = pattern.len();
+                for (i, &byte) in bytes.iter().enumerate() {
+                    if byte != pattern[i % pat_len] {
+                        return Ok(false);
+                    }
+                }
+            }
         }
-
         Ok(true)
     }
 }
 
 impl Default for Generator {
     fn default() -> Self {
-        Self::new()
+        Self::new(Pattern::LCG)
     }
 }
 

--- a/tests/fixture.rs
+++ b/tests/fixture.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+
+mod common;
+
+use common::fixture::{create_input_file, verify_file, BLOCK_SIZE};
+use common::random::Pattern;
+use common::test_dir::*;
+
+#[test]
+fn test_file_create_verify_repeating() -> Result<()> {
+    let mut td = TestDir::new()?;
+    let file_size = (BLOCK_SIZE * 10) as u64;
+    let buffer: Vec<u8> = (0..BLOCK_SIZE).map(|x| x as u8).collect(); // Incrementing byte buffer
+    let input = create_input_file(&mut td, file_size, 1, Pattern::Repeating(buffer.clone()))?;
+
+    verify_file(&input, file_size, 1, Pattern::Repeating(buffer.clone()))?;
+
+    Ok(())
+}
+
+#[test]
+fn test_file_create_verify_fill() -> Result<()> {
+    let mut td = TestDir::new()?;
+    let file_size = (BLOCK_SIZE * 10) as u64;
+    let input = create_input_file(&mut td, file_size, 1, Pattern::SingleByte(0xFF))?;
+
+    verify_file(&input, file_size, 1, Pattern::SingleByte(0xFF))?;
+
+    Ok(())
+}
+
+#[test]
+fn test_file_create_verify_random() -> Result<()> {
+    let mut td = TestDir::new()?;
+    let file_size = (BLOCK_SIZE * 10) as u64;
+    let input = create_input_file(&mut td, file_size, 1, Pattern::LCG)?;
+
+    verify_file(&input, file_size, 1, Pattern::LCG)?;
+
+    Ok(())
+}

--- a/tests/pack.rs
+++ b/tests/pack.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
+use rand::Rng;
 
 mod common;
 
-use common::fixture::*;
+use blk_archive::archive;
+use common::blk_archive::PackResponse;
+use common::fixture::{create_archive, create_input_file, BLOCK_SIZE};
+use common::random::Pattern;
 use common::test_dir::*;
 
 //-----------------------------------------
@@ -10,27 +14,95 @@ use common::test_dir::*;
 #[test]
 fn pack_one_file() -> Result<()> {
     let mut td = TestDir::new()?;
-    let archive = create_archive(&mut td)?;
+    let archive = create_archive(&mut td, true)?;
 
     let file_size = 16 * 1024 * 1024;
     let seed = 1;
-    let input = create_input_file(&mut td, file_size, seed)?;
-    let stream = archive.pack(&input)?;
+    let input = create_input_file(&mut td, file_size, seed, Pattern::LCG)?;
+    let stream = archive.pack(&input)?.stream_id;
     archive.verify(&input, &stream)
 }
 
 #[test]
 fn pack_same_file_multiple_times() -> Result<()> {
     let mut td = TestDir::new()?;
-    let archive = create_archive(&mut td)?;
+    let archive = create_archive(&mut td, true)?;
 
     let file_size = 16 * 1024 * 1024;
     let seed = 1;
-    let input = create_input_file(&mut td, file_size, seed)?;
+    let input = create_input_file(&mut td, file_size, seed, Pattern::LCG)?;
     let streams = (0..3)
         .map(|_| archive.pack(&input))
         .collect::<Result<Vec<_>>>()?;
-    streams.iter().try_for_each(|s| archive.verify(&input, s))
+    streams
+        .iter()
+        .try_for_each(|s| archive.verify(&input, &s.stream_id))
 }
 
+fn pack_common_verify_stats(file_size: u64, pattern: Pattern) -> Result<PackResponse> {
+    let mut td = TestDir::new()?;
+    let seed = 1;
+
+    let archive = create_archive(&mut td, false)?;
+    let input = create_input_file(&mut td, file_size, seed, pattern.clone())?;
+    let response = archive.pack(&input)?;
+
+    assert_eq!(response.stats.mapped_size, file_size);
+
+    match pattern {
+        Pattern::LCG => {
+            assert_eq!(file_size, response.stats.data_written);
+            assert_eq!(response.stats.fill_size, 0);
+        }
+        Pattern::SingleByte(_a) => {
+            assert_eq!(response.stats.data_written, 0);
+            assert_eq!(response.stats.fill_size, file_size);
+        }
+        Pattern::Repeating(pattern) => {
+            assert_eq!(response.stats.data_written, pattern.len() as u64);
+            assert_eq!(response.stats.fill_size, 0);
+        }
+    }
+
+    archive.verify(&input, &response.stream_id)?;
+    Ok(response)
+}
+
+#[test]
+fn pack_zero_verify_stats() -> Result<()> {
+    let file_size = 16 * 1024 * 1024;
+    pack_common_verify_stats(file_size, Pattern::SingleByte(0))?;
+    Ok(())
+}
+
+#[test]
+fn pack_duplicate_verify_stats() -> Result<()> {
+    let file_size = 16 * 1024 * 1024;
+    let buffer: Vec<u8> = (0..BLOCK_SIZE).map(|x| x as u8).collect(); // Incrementing byte buffer
+    pack_common_verify_stats(file_size, Pattern::Repeating(buffer))?;
+    Ok(())
+}
+
+#[test]
+fn pack_random_verify_stats() -> Result<()> {
+    let file_size_start = 16 * 1024 * 1024 as u64;
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..10 {
+        let r_increase = rng.gen_range(1024..archive::SLAB_SIZE_TARGET);
+        let size = file_size_start + r_increase as u64;
+
+        pack_common_verify_stats(size, Pattern::LCG)?;
+    }
+
+    for s in vec![
+        file_size_start,
+        file_size_start - 10,
+        file_size_start + archive::SLAB_SIZE_TARGET as u64 + 10,
+    ] {
+        pack_common_verify_stats(s, Pattern::LCG)?;
+    }
+
+    Ok(())
+}
 //-----------------------------------------

--- a/tests/unpack.rs
+++ b/tests/unpack.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 mod common;
 
+use crate::common::random::Pattern;
 use common::fixture::*;
 use common::test_dir::*;
 
@@ -10,16 +11,16 @@ use common::test_dir::*;
 #[test]
 fn unpack_file() -> Result<()> {
     let mut td = TestDir::new()?;
-    let archive = create_archive(&mut td)?;
+    let archive = create_archive(&mut td, true)?;
 
     let file_size = 16 * 1024 * 1024;
     let seed = 1;
-    let input = create_input_file(&mut td, file_size, seed)?;
-    let stream = archive.pack(&input)?;
+    let input = create_input_file(&mut td, file_size, seed, Pattern::LCG)?;
+    let stream = archive.pack(&input)?.stream_id;
 
     let output = td.mk_path("output.bin");
     archive.unpack(&stream, &output, true)?;
-    verify_file(&output, file_size, seed)
+    verify_file(&output, file_size, seed, Pattern::LCG)
 }
 
 //-----------------------------------------

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 mod common;
 
+use crate::common::random::Pattern;
 use common::fixture::*;
 use common::process::*;
 use common::test_dir::*;
@@ -11,13 +12,13 @@ use common::test_dir::*;
 #[test]
 fn verify_incompleted_archive_should_fail() -> Result<()> {
     let mut td = TestDir::new()?;
-    let archive = create_archive(&mut td)?;
+    let archive = create_archive(&mut td, true)?;
 
     let file_size = 16 * 1024 * 1024;
     let seed = 1;
-    let input = create_input_file(&mut td, file_size, seed)?;
-    let input_short = create_input_file(&mut td, file_size - 1, seed)?;
-    let stream = archive.pack(&input_short)?;
+    let input = create_input_file(&mut td, file_size, seed, Pattern::LCG)?;
+    let input_short = create_input_file(&mut td, file_size - 1, seed, Pattern::LCG)?;
+    let stream = archive.pack(&input_short)?.stream_id;
     run_fail(archive.verify_cmd(&input, &stream))?;
     Ok(())
 }
@@ -25,13 +26,13 @@ fn verify_incompleted_archive_should_fail() -> Result<()> {
 #[test]
 fn verify_incompleted_file_should_fail() -> Result<()> {
     let mut td = TestDir::new()?;
-    let archive = create_archive(&mut td)?;
+    let archive = create_archive(&mut td, true)?;
 
     let file_size = 16 * 1024 * 1024;
     let seed = 1;
-    let input = create_input_file(&mut td, file_size, seed)?;
-    let input_short = create_input_file(&mut td, file_size - 1, seed)?;
-    let stream = archive.pack(&input)?;
+    let input = create_input_file(&mut td, file_size, seed, Pattern::LCG)?;
+    let input_short = create_input_file(&mut td, file_size - 1, seed, Pattern::LCG)?;
+    let stream = archive.pack(&input)?.stream_id;
     run_fail(archive.verify_cmd(&input_short, &stream))?;
     Ok(())
 }


### PR DESCRIPTION
The main focus of this PR is to add coverage for the pack stats.  In the process I found a bug which I posted a separate PR, ~but I've also included the commit in this PR too, so that the tests would pass~.  Additionally this PR adds

* Additional JSON output for pack
* Ouput JSON for unpack
* Update yaml library to a supported one
* Adds an option to archive create to enable/disable data slab compression, defaults to yes
* ~Uses test-bd target for additional tests (installs and loads kernel driver into CI VM)~